### PR TITLE
Minimize extra memory allocations in Stream#read and Stream#read_partial

### DIFF
--- a/async-io.gemspec
+++ b/async-io.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 	spec.has_rdoc      = "yard"
 
 	spec.add_dependency "async", "~> 1.3"
-	spec.add_development_dependency "async-rspec", "~> 1.6"
+	spec.add_development_dependency "async-rspec", "~> 1.7"
 
 	spec.required_ruby_version = '~> 2.3'
 

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -21,6 +21,8 @@
 require 'async/io/stream'
 
 RSpec.describe Async::IO::Stream do
+	include_context Async::RSpec::Memory
+	
 	let(:io) {StringIO.new}
 	let(:stream) {Async::IO::Stream.new(io)}
 	
@@ -46,6 +48,16 @@ RSpec.describe Async::IO::Stream do
 			
 			expect(stream.read(20)).to be == "o World"
 			expect(stream).to be_eof
+		end
+		
+		context "with large content" do
+			let!(:io) { StringIO.new("a" * 5*1024*1024) }
+			
+			it "allocates expected amount of bytes" do
+				expect do
+					stream.read(16*1024).clear until stream.eof?
+				end.to limit_allocations(size: 100*1024)
+			end
 		end
 	end
 	
@@ -95,6 +107,16 @@ RSpec.describe Async::IO::Stream do
 			expect(io).to receive(:read).and_call_original.once
 			
 			expect(stream.read_partial(11)).to be == "Hello World"
+		end
+		
+		context "with large content" do
+			let!(:io) { StringIO.new("a" * 5*1024*1024) }
+			
+			it "allocates expected amount of bytes" do
+				expect do
+					stream.read_partial(16*1024).clear until stream.eof?
+				end.to limit_allocations(size: 100*1024)
+			end
 		end
 	end
 	

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe Async::IO::Stream do
 	end
 	
 	describe '#read_until' do
-		include_context Async::RSpec::Memory
-		
 		it "can read a line" do
 			io.write("hello\nworld\n")
 			io.seek(0)
@@ -73,13 +71,14 @@ RSpec.describe Async::IO::Stream do
 			expect(stream.read_until("\n")).to be_nil
 		end
 		
-		it "minimises allocations" do
-			io.write("hello\nworld\n")
-			io.seek(0)
+		context "with large content" do
+			let!(:io) { StringIO.new("a" * 5*1024*1024 + "b") }
 			
-			expect do
-				stream.read_until("\n")
-			end.to limit_allocations(String => 3)
+			it "allocates expected amount of bytes" do
+				expect do
+					stream.read_until("b").clear
+				end.to limit_allocations(size: 100*1024)
+			end
 		end
 	end
 	


### PR DESCRIPTION
These changes minimize extra memory allocations, making it possible to read from very large streams with near-constant memory usage.

For some reason the following change made the difference in this effort:

```diff
- result = @read_buffer.dup
- @read_buffer.clear
+ result = @read_buffer
+ @read_buffer = BinaryString.new
```

I'm not sure I understand why, I was mostly just trying different things until something worked.

When I tested `Async::HTTP::Body::Fixed` and `Async::HTTP::Body::Chunked` with these changes, they also showed very little memory allocation. BTW, I'm about to submit a PR which adds specs for both of those body classes.

For some reason this change didn't bring a positive effect on `falcon` itself. I will still have to investigate that.