### PR TITLE
Delegate IO::TCPSocket#read -> IO::Stream#read

### DIFF
--- a/lib/async/io/tcp_socket.rb
+++ b/lib/async/io/tcp_socket.rb
@@ -57,7 +57,7 @@ module Async
 			
 			attr :buffer
 			
-			def_delegators :@buffer, :gets, :puts, :flush
+			def_delegators :@buffer, :gets, :puts, :flush, :read
 		end
 		
 		# Asynchronous TCP server wrappper.


### PR DESCRIPTION
Currently, TCPSocket#read(n) may return not enough bytes, which is incorrect, should use Stream#read instead.