### PR TITLE
Do not leak socket when `Async::IO::Socket.connect` is interrupted by a Timeout

### DIFF
--- a/lib/async/io/socket.rb
+++ b/lib/async/io/socket.rb
@@ -140,7 +140,7 @@ module Async
 				begin
 					wrapper.connect(remote_address.to_sockaddr)
 					task.annotate "connected to #{remote_address.inspect}"
-				rescue
+				rescue Exception
 					wrapper.close
 					raise
 				end

--- a/spec/async/io/socket_spec.rb
+++ b/spec/async/io/socket_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Async::IO::Socket do
 				Async::IO::Socket.connect(address)
 			end.to raise_error(Errno::ECONNREFUSED)
 		end
+		
+		it "should close the socket when interrupted by a timeout" do
+			wrapper = double()
+			expect(Async::IO::Socket).to receive(:build).and_return(wrapper)
+			expect(wrapper).to receive(:connect).and_raise Async::TimeoutError
+			expect(wrapper).to receive(:close)
+			expect do
+				Async::IO::Socket.connect(address)
+			end.to raise_error(Async::TimeoutError)
+		end
 	end
 	
 	describe '#bind' do


### PR DESCRIPTION
Fixes #14