### PR TITLE
Add missing require in ssl_server_spec.rb

### DIFF
--- a/spec/async/io/ssl_server_spec.rb
+++ b/spec/async/io/ssl_server_spec.rb
@@ -19,6 +19,7 @@
 # THE SOFTWARE.
 
 require 'async/io/ssl_socket'
+require 'async/io/ssl_endpoint'
 
 require 'async/rspec/ssl'
 require_relative 'generic_examples'


### PR DESCRIPTION
Otherwise, ` bundle exec rspec spec/async/io/ssl_server_spec.rb` fails.

From https://github.com/oracle/truffleruby/issues/1721#issuecomment-511551044