### PR TITLE
Use a smaller size for the Async::IO::Stream performance spec

### DIFF
--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Async::IO::Stream do
 			data = nil
 			
 			duration = Async::Clock.measure do
-				data = stream.read(4*1024**3)
+				data = stream.read(1024**3)
 			end
 			
 			size = data.bytesize / 1024**2


### PR DESCRIPTION
* 4GB is too large for 32-bit systems and for JVM arrays.
  It's also quite high in memory usage while running specs.

From https://github.com/oracle/truffleruby/issues/1721#issuecomment-512240158