### PR TITLE
Expose `close_on_exec:` option in shared endpoint.

### DIFF
--- a/lib/async/io/shared_endpoint.rb
+++ b/lib/async/io/shared_endpoint.rb
@@ -27,10 +27,10 @@ module Async
 		# Pre-connect and pre-bind sockets so that it can be used between processes.
 		class SharedEndpoint < Endpoint
 			# Create a new `SharedEndpoint` by binding to the given endpoint.
-			def self.bound(endpoint, backlog = Socket::SOMAXCONN)
+			def self.bound(endpoint, backlog: Socket::SOMAXCONN, close_on_exec: false)
 				wrappers = endpoint.bound do |server|
 					server.listen(backlog)
-					server.close_on_exec = false
+					server.close_on_exec = close_on_exec
 					server.reactor = nil
 				end
 				
@@ -38,10 +38,10 @@ module Async
 			end
 			
 			# Create a new `SharedEndpoint` by connecting to the given endpoint.
-			def self.connected(endpoint)
+			def self.connected(endpoint, close_on_exec: false)
 				wrapper = endpoint.connect
 				
-				wrapper.close_on_exec = false
+				wrapper.close_on_exec = close_on_exec
 				wrapper.reactor = nil
 				
 				return self.new(endpoint, [wrapper])


### PR DESCRIPTION
## Description

Sometimes we want to pre-bind endpoints without inheriting them by child processes.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
