### PR TITLE
Avoid 2 "shadowing outer local variable - task"

### DIFF
--- a/lib/async/io/socket.rb
+++ b/lib/async/io/socket.rb
@@ -66,8 +66,8 @@ module Async
 				
 				return wrapper, address unless block_given?
 				
-				task.async do |task|
-					task.annotate "incoming connection #{address.inspect} [fd=#{wrapper.fileno}]"
+				task.async do |t|
+					t.annotate "incoming connection #{address.inspect} [fd=#{wrapper.fileno}]"
 					
 					begin
 						yield wrapper, address
@@ -162,8 +162,8 @@ module Async
 				
 				return wrapper unless block_given?
 				
-				task.async do |task|
-					task.annotate "binding to #{wrapper.local_address.inspect}"
+				task.async do |t|
+					t.annotate "binding to #{wrapper.local_address.inspect}"
 					
 					begin
 						yield wrapper, task


### PR DESCRIPTION
## Description

This PR attempts to get rid a an emitted Ruby warning seen when running tests in another project.

    gems/async-io-1.32.0/lib/async/io/socket.rb:69: warning: shadowing outer local variable - task
    gems/async-io-1.32.0/lib/async/io/socket.rb:165: warning: shadowing outer local variable - task

### Types of Changes

- Maintenance.

### Testing

...