### PR TITLE
Fix encoding and frozenness of zero-length reads

### DIFF
--- a/lib/async/io/generic.rb
+++ b/lib/async/io/generic.rb
@@ -116,7 +116,7 @@ module Async
 				end
 				
 				if length
-					return "" if length <= 0
+					return String.new(encoding: Encoding::BINARY) if length <= 0
 					
 					# Fast path:
 					if buffer = self.sysread(length, buffer)

--- a/lib/async/io/stream.rb
+++ b/lib/async/io/stream.rb
@@ -72,7 +72,7 @@ module Async
 			
 			# Reads `size` bytes from the stream. If size is not specified, read until end of file.
 			def read(size = nil)
-				return '' if size == 0
+				return String.new(encoding: Encoding::BINARY) if size == 0
 				
 				if size
 					until @eof or @read_buffer.bytesize >= size
@@ -93,7 +93,7 @@ module Async
 			
 			# Read at most `size` bytes from the stream. Will avoid reading from the underlying stream if possible.
 			def read_partial(size = nil)
-				return '' if size == 0
+				return String.new(encoding: Encoding::BINARY) if size == 0
 			
 				if !@eof and @read_buffer.empty?
 					fill_read_buffer

--- a/spec/async/io/generic_examples.rb
+++ b/spec/async/io/generic_examples.rb
@@ -70,4 +70,26 @@ RSpec.shared_examples Async::IO do
 		
 		expect(subject.read).to be == data
 	end
+	
+	context "has the right encoding" do
+		it "with a normal read" do
+			io.write(data)
+			expect(subject.read(1).encoding).to be == Encoding::BINARY
+		end
+		
+		it "with a zero-length read" do
+			expect(subject.read(0).encoding).to be == Encoding::BINARY
+		end
+	end
+
+	context "are not frozen" do
+		it "with a normal read" do
+			io.write(data)
+			expect(subject.read(1).frozen?).to be == false
+		end
+		
+		it "with a zero-length read" do
+			expect(subject.read(0).frozen?).to be == false
+		end
+	end
 end

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -295,6 +295,16 @@ RSpec.describe Async::IO::Stream do
 					expect(buffer.size).to be == subject.block_size
 				end
 			end
+			
+			context "has the right encoding" do
+				it "with a normal partial_read" do
+					expect(subject.read_partial(1).encoding).to be == Encoding::BINARY
+				end
+				
+				it "with a zero-length partial_read" do
+					expect(subject.read_partial(0).encoding).to be == Encoding::BINARY
+				end
+			end
 		end
 		
 		describe '#write' do


### PR DESCRIPTION
## Description

This fixes two problems related to zero-length reads that broke protocol-websocket.

 1. Zero-length reads were of a different encoding (UTF-8 vs BINARY) compared to all other reads.
 2. Zero-length reads were frozen, when all other reads were not.

### Types of Changes

- Bug fix.

### Testing

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I tested my changes in staging.
- [ ] I tested my changes in production.
