### PR TITLE
gems.rb: Conditionally install bake-modernize (not on JRuby).

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -17,7 +17,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
-          - 3.0
+          - "3.0"
         
         experimental: [false]
         env: [""]
@@ -30,6 +30,7 @@ jobs:
           - os: ubuntu
             ruby: jruby
             experimental: true
+            env: "JRUBY_OPTS=-X+O"
           - os: ubuntu
             ruby: head
             experimental: true

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -30,7 +30,7 @@ jobs:
           - os: ubuntu
             ruby: jruby
             experimental: true
-            env: "JRUBY_OPTS=-X+O"
+            env: 'JRUBY_OPTS="-X+O --debug"'
           - os: ubuntu
             ruby: head
             experimental: true

--- a/async-io.gemspec
+++ b/async-io.gemspec
@@ -16,13 +16,4 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 2.5"
 	
 	spec.add_dependency "async", "~> 1.14"
-	
-	spec.add_development_dependency "async-container", "~> 0.15"
-	spec.add_development_dependency "async-rspec", "~> 1.10"
-	spec.add_development_dependency "bake"
-	spec.add_development_dependency "bake-bundler"
-	spec.add_development_dependency "bake-modernize"
-	spec.add_development_dependency "bundler"
-	spec.add_development_dependency "covered"
-	spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -2,12 +2,22 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in async-io.gemspec
 gemspec
+
+group :development do
+	gem "async-container", "~> 0.15"
+	gem "async-rspec", "~> 1.10"
+	gem "bake"
+	gem "bake-bundler"
+	gem "bake-modernize" unless defined?(JRUBY_VERSION)
+	gem "bundler"
+	gem "covered"
+	gem "rspec", "~> 3.0"
+end
 
 group :test do
 	gem 'benchmark-ips'
 	gem 'ruby-prof', platforms: :mri
-	
+
 	gem 'http'
 end

--- a/spec/async/io/shared_endpoint/server_spec.rb
+++ b/spec/async/io/shared_endpoint/server_spec.rb
@@ -67,6 +67,6 @@ RSpec.describe Async::Container::Forked, if: Process.respond_to?(:fork) do
 	it_behaves_like Async::IO::SharedEndpoint, described_class
 end
 
-RSpec.describe Async::Container::Threaded, if: RUBY_PLATFORM !~ /darwin/ do
+RSpec.describe Async::Container::Threaded, if: (RUBY_PLATFORM !~ /darwin/ && RUBY_ENGINE != "jruby") do
 	it_behaves_like Async::IO::SharedEndpoint, described_class
 end


### PR DESCRIPTION
## Description

CI fails, this PR attempts to make the build fail instead of error out. JRuby-related.

This fixes #45.

- JRuby: Avoid warning "Script coverage disabled: unknown event: script_compiled"
- JRuby: Enable ObjectSpace.
- JRuby: Skip a test to see if it was the only slow one. (It wasn't.)


### Types of Changes

- Maintenance.

### Testing

I ran the CI, and noted that it now runs-but-fails, as opposed to erroring out.