### PR TITLE
Fix `SSLSocket#close_write` and related tests.

### DIFF
--- a/lib/async/io/ssl_socket.rb
+++ b/lib/async/io/ssl_socket.rb
@@ -89,11 +89,12 @@ module Async
 			end
 			
 			def close_write
-				self.shutdown(Socket::SHUT_WR)
+				# Invokes SSL_shutdown, which sends a close_notify message to the peer.
+				@io.__send__(:stop)
 			end
 			
 			def close_read
-				self.shutdown(Socket::SHUT_RD)
+				@io.to_io.shutdown(Socket::SHUT_RD)
 			end
 			
 			def shutdown(how)

--- a/spec/async/io/ssl_server_spec.rb
+++ b/spec/async/io/ssl_server_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Async::IO::SSLServer do
 				end
 				
 				server_task.stop
-			end
+			end.wait
 		end
 	end
 	
@@ -123,7 +123,7 @@ RSpec.describe Async::IO::SSLServer do
 				end
 				
 				server_task.stop
-			end
+			end.wait
 		end
 		
 		it 'it fails with invalid host' do


### PR DESCRIPTION
It looks like `SSLSocket#close_write` wasn't working and the tests were a little racy so they didn't pick up the failure.

Related:
- https://github.com/ruby/openssl/issues/609
- https://github.com/ruby/openssl/issues/610

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
