### PR TITLE
The options need to be passed through to the address endpoints.

### DIFF
--- a/lib/async/io/peer.rb
+++ b/lib/async/io/peer.rb
@@ -18,6 +18,9 @@ module Async
 				# If we can wait for the socket to become readable, we know that the socket may still be open.
 				result = to_io.recv_nonblock(1, MSG_PEEK, exception: false)
 				
+				# No data was available - newer Ruby can return nil instead of empty string:
+				return false if result.nil?
+				
 				# Either there was some data available, or we can wait to see if there is data avaialble.
 				return !result.empty? || result == :wait_readable
 				

--- a/lib/async/io/shared_endpoint.rb
+++ b/lib/async/io/shared_endpoint.rb
@@ -50,10 +50,11 @@ module Async
 			
 			def local_address_endpoint(**options)
 				endpoints = @wrappers.map do |wrapper|
-					AddressEndpoint.new(wrapper.to_io.local_address)
+					# Forward the options to the internal endpoints:
+					AddressEndpoint.new(wrapper.to_io.local_address, **options)
 				end
 				
-				return CompositeEndpoint.new(endpoints, **options)
+				return CompositeEndpoint.new(endpoints)
 			end
 			
 			def remote_address_endpoint(**options)


### PR DESCRIPTION
Updating `async-http` to use `CompositeEndpoint` failed during tests that depend on client timeouts. It turns out that this method should at least set the options on the internal endpoints.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
