### PR TITLE
Fix race condition in `fill_read_buffer`

### DIFF
--- a/lib/async/io/stream.rb
+++ b/lib/async/io/stream.rb
@@ -46,9 +46,6 @@ module Async
 				@read_buffer = Buffer.new
 				@write_buffer = Buffer.new
 				@drain_buffer = Buffer.new
-				
-				# Used as destination buffer for underlying reads.
-				@input_buffer = Buffer.new
 			end
 			
 			attr :io
@@ -244,18 +241,13 @@ module Async
 				# This effectively ties the input and output stream together.
 				flush
 				
-				if @read_buffer.empty?
-					if @io.read_nonblock(size, @read_buffer, exception: false)
-						# Console.logger.debug(self, name: "read") {@read_buffer.inspect}
-						return true
-					end
-				else
-					if chunk = @io.read_nonblock(size, @input_buffer, exception: false)
-						@read_buffer << chunk
-						# Console.logger.debug(self, name: "read") {@read_buffer.inspect}
+				input_buffer = Buffer.new
+		
+				if chunk = @io.read_nonblock(size, input_buffer, exception: false)
+					@read_buffer << chunk
+					# Console.logger.debug(self, name: "read") {@read_buffer.inspect}
 						
-						return true
-					end
+					return true
 				end
 				
 				# else for both cases above:


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->
`fill_read_buffer` has a race condition which can potentially lead to data loss. Consider the following sequence of events:

- init
- Fiber 1 issues a `read` of 16K bytes. This invokes `fill_read_buffer` with a size of `BLOCK_SIZE` (say, 64K) bytes.
- `@read_buffer` is currently empty, so we call `@io.read_nonblock(size, input_buffer, exception: false)`
- Suppose the underlying `@io` is a socket, and the socket is empty. Then, `@io.read_nonblock` will yield (on stable-v1 because of the `async_send` instrumentation, and on main because of the `io_read` hook in `rb_fiber_scheduler_io_read_memory` in the VM, leading to `io_wait` when the read would've blocked. 
- Suppose Fiber 2 issues a `read` of 16K bytes. This invokes `fill_read_buffer` with a size of `BLOCK_SIZE` (64K) bytes.
- Suppose the read succeeds, it consumes 16K bytes, leaving 48K bytes in `@read_buffer`
- Fiber 1 resumes, and retries `@io.read_nonblock(size, input_buffer, exception: false)`
- The read succeeds. **But read_nonblock nukes the contents of `input_buffer`** leading to a data loss of 48K bytes.

This PR fixes this race condition by using a fresh buffer every time

cc @fables-tales

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
