### PR TITLE
Fix for socket file not being reused even when not bound

### DIFF
--- a/lib/async/io/unix_endpoint.rb
+++ b/lib/async/io/unix_endpoint.rb
@@ -35,8 +35,8 @@ module Async
 				Socket.bind(@address, **@options, &block)
 			rescue Errno::EADDRINUSE
 				# If you encounter EADDRINUSE from `bind()`, you can check if the socket is actually accepting connections by attempting to `connect()` to it. If the socket is still bound by an active process, the connection will succeed. Otherwise, it should be safe to `unlink()` the path and try again.
-				if !bound? && File.exist?(@path)
-					File.unlink(@path)
+				if !bound?
+					FileUtils.safe_unlink(@path)
 					retry
 				else
 					raise

--- a/spec/async/io/unix_endpoint_spec.rb
+++ b/spec/async/io/unix_endpoint_spec.rb
@@ -39,6 +39,20 @@ RSpec.describe Async::IO::UNIXEndpoint do
 		
 		server_task.stop
 	end
+
+  it "should not fail to bind if there are no existing bindings on the socket" do
+    server_task1 = reactor.async do
+			subject.bind
+		end
+		server_task1.stop
+
+    server_task2 = reactor.async do
+      expect do
+				subject.bind
+			end.to_not raise_error
+    end
+    server_task2.stop
+  end
 	
 	it "should fails to bind if there is an existing binding" do
 		condition = Async::Condition.new

--- a/spec/async/io/unix_endpoint_spec.rb
+++ b/spec/async/io/unix_endpoint_spec.rb
@@ -5,7 +5,6 @@
 
 require 'async/io/unix_endpoint'
 require 'async/io/stream'
-require 'fileutils'
 
 RSpec.describe Async::IO::UNIXEndpoint do
 	include_context Async::RSpec::Reactor
@@ -13,14 +12,6 @@ RSpec.describe Async::IO::UNIXEndpoint do
 	let(:data) {"The quick brown fox jumped over the lazy dog."} 
 	let(:path) {File.join(__dir__, "unix-socket")}
 	subject {described_class.unix(path)}
-	
-	before(:each) do
-		FileUtils.rm_f path
-	end
-	
-	after do
-		FileUtils.rm_f path
-	end
 	
 	it "should echo data back to peer" do
 		server_task = reactor.async do


### PR DESCRIPTION
In my machine, when I `Ctrl+C` (using falcon supervisor), supervisor.ipc remains and when I restart the server, I get EADDRINUSE

Found that `File.exist?(@path)` is returning false for such a file even though `ls -al` lists the file

Using `FileUtils.safe_unlink` instead of `File.unlink` to safely remove the file when it exists without any error

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
