### PR TITLE
Add functionality to be able to peek `n` bytes off the wire

### DIFF
--- a/lib/async/io/stream.rb
+++ b/lib/async/io/stream.rb
@@ -134,9 +134,9 @@ module Async
 						# Don't read less than @block_size to avoid lots of small reads:
 						fill_read_buffer(read_size > @block_size ? read_size : @block_size)
 					end
-					return @read_buffer[..[size, @read_buffer.size].min]
+					return @read_buffer[..([size, @read_buffer.size].min - 1)]
 				end
-				until yield(@read_buffer) or @eof
+				until (block_given? && yield(@read_buffer)) or @eof
 					fill_read_buffer
 				end
 			end

--- a/lib/async/io/stream.rb
+++ b/lib/async/io/stream.rb
@@ -125,7 +125,17 @@ module Async
 				return matched
 			end
 			
-			def peek
+			def peek(size = nil)
+				if size
+					until @eof or @read_buffer.bytesize >= size
+						# Compute the amount of data we need to read from the underlying stream:
+						read_size = size - @read_buffer.bytesize
+						
+						# Don't read less than @block_size to avoid lots of small reads:
+						fill_read_buffer(read_size > @block_size ? read_size : @block_size)
+					end
+					return @read_buffer[..[size, @read_buffer.size].min]
+				end
 				until yield(@read_buffer) or @eof
 					fill_read_buffer
 				end

--- a/lib/async/io/stream.rb
+++ b/lib/async/io/stream.rb
@@ -139,6 +139,7 @@ module Async
 				until (block_given? && yield(@read_buffer)) or @eof
 					fill_read_buffer
 				end
+				return @read_buffer
 			end
 			
 			def gets(separator = $/, **options)

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -210,6 +210,17 @@ RSpec.describe Async::IO::Stream do
 				expect(subject.read_partial(20)).to be == "o World"
 				expect(subject).to be_eof
 			end
+
+			it "peeks everything when requested bytes is too large" do
+				io.write "Hello World"
+				io.seek(0)
+				
+				expect(subject.io).to receive(:read_nonblock).and_call_original.once
+				
+				expect(subject.peek(400)).to be == "Hello World"
+				expect(subject.read_partial(400)).to be == "Hello World"
+				expect(subject).to be_eof
+			end
 		
 			context "with large content", if: !Async::IO.buffer? do
 				it "allocates expected amount of bytes" do

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe Async::IO::Stream do
 				io.write "Hello World"
 				io.seek(0)
 				
-				expect(subject.io).to receive(:read_nonblock).and_call_original.once
+				expect(subject.io).to receive(:read_nonblock).and_call_original.twice
 				
 				expect(subject.peek(400)).to be == "Hello World"
 				expect(subject.read_partial(400)).to be == "Hello World"

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -184,6 +184,32 @@ RSpec.describe Async::IO::Stream do
 				expect(subject.read_partial(20)).to be == "o World"
 				expect(subject).to be_eof
 			end
+			
+			it "should peek everything" do
+				io.write "Hello World"
+				io.seek(0)
+				
+				expect(subject.io).to receive(:read_nonblock).and_call_original.twice
+				
+				expect(subject.peek).to be == "Hello World"
+				expect(subject.read).to be == "Hello World"
+				expect(subject).to be_eof
+			end
+		
+			it "should peek only the amount requested" do
+				io.write "Hello World"
+				io.seek(0)
+				
+				expect(subject.io).to receive(:read_nonblock).and_call_original.once
+				
+				expect(subject.peek(4)).to be == "Hell"
+				expect(subject.read_partial(4)).to be == "Hell"
+				expect(subject).to_not be_eof
+				
+				expect(subject.peek(20)).to be == "o World"
+				expect(subject.read_partial(20)).to be == "o World"
+				expect(subject).to be_eof
+			end
 		
 			context "with large content", if: !Async::IO.buffer? do
 				it "allocates expected amount of bytes" do

--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Async::IO::Stream do
 				io.write "Hello World"
 				io.seek(0)
 				
-				expect(subject.io).to receive(:read_nonblock).and_call_original.once
+				expect(subject.io).to receive(:read_nonblock).and_call_original.twice
 				
 				expect(subject.peek(4)).to be == "Hell"
 				expect(subject.read_partial(4)).to be == "Hell"


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->
To fix https://github.com/socketry/protocol-http2/issues/14 , one approach is to maintain the invariant that the read buffer / wire is always frame-aligned. We propose doing this by always reading a full frame at a time. To do this, instead of reading data off the wire when reading the header for an H/2 frame, we just peek the header and then read the full frame.
## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
