### PR TITLE
Add methods for generating shared endpoints, consistent with `io-endpoint`.

### DIFF
--- a/lib/async/io/endpoint.rb
+++ b/lib/async/io/endpoint.rb
@@ -78,23 +78,6 @@ module Async
 				end
 			end
 			
-			# Map all endpoints by invoking `#bind`.
-			# @yield the bound wrapper.
-			def bound
-				wrappers = []
-				
-				self.each do |endpoint|
-					wrapper = endpoint.bind
-					wrappers << wrapper
-					
-					yield wrapper
-				end
-				
-				return wrappers
-			ensure
-				wrappers.each(&:close) if $!
-			end
-			
 			# Create an Endpoint instance by URI scheme. The host and port of the URI will be passed to the Endpoint factory method, along with any options.
 			#
 			# @param string [String] URI as string. Scheme will decide implementation used.

--- a/lib/async/io/ssl_endpoint.rb
+++ b/lib/async/io/ssl_endpoint.rb
@@ -65,7 +65,9 @@ module Async
 						yield SSLServer.new(server, context)
 					end
 				else
-					return SSLServer.new(@endpoint.bind, context)
+					@endpoint.bind.map do |server|
+						SSLServer.new(server, context)
+					end
 				end
 			end
 			


### PR DESCRIPTION
Previously, it was common to write `Async::IO::SharedEndpoint.bound(...)` or `.connected(...)`. However, this makes it hard to transparently swap in the `io-endpoint` gem. Replace this poor design with a method.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
