### PR TITLE
Require shared endpoint by default.

### DIFF
--- a/lib/async/io.rb
+++ b/lib/async/io.rb
@@ -11,6 +11,7 @@ require_relative "io/version"
 
 require_relative "io/endpoint"
 require_relative "io/endpoint/each"
+require_relative "io/shared_endpoint"
 
 module Async
 	module IO


### PR DESCRIPTION
To avoid having to have library-specific requires, let's require shared endpoint by default.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
