### PR TITLE
Test for graceful close on shared bound endpoints.

### DIFF
--- a/lib/async/io/shared_endpoint.rb
+++ b/lib/async/io/shared_endpoint.rb
@@ -77,16 +77,9 @@ module Async
 				task = Async::Task.current
 				
 				@wrappers.each do |server|
-					server = server.dup
-					
 					task.async do |task|
 						task.annotate "binding to #{server.inspect}"
-						
-						begin
-							yield server, task
-						ensure
-							server.close
-						end
+						yield server, task
 					end
 				end
 			end
@@ -109,9 +102,9 @@ module Async
 				end
 			end
 			
-			def accept(backlog = nil, &block)
+			def accept(backlog = nil, **options, &block)
 				bind do |server|
-					server.accept_each(&block)
+					server.accept_each(**options, &block)
 				end
 			end
 			


### PR DESCRIPTION
This is a requirement for implementing a convenient graceful shutdown sequence in Falcon.

Essentially, closing the bound endpoint will cause connections to no longer be accepted.

The specifics of the implementation are not specified, as they might change slightly in the `io-endpoint` gem.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
