### PR TITLE
`Async::IO::Stream` can handle native IO.

### DIFF
--- a/spec/async/io/stream_spec.rb
+++ b/spec/async/io/stream_spec.rb
@@ -23,6 +23,26 @@ RSpec.describe Async::IO::Stream do
 		end
 	end
 	
+	context "native I/O", if: RUBY_VERSION >= "3.1" do
+		let(:sockets) do
+			@sockets = ::Socket.pair(::Socket::AF_UNIX, ::Socket::SOCK_STREAM)
+		end
+		
+		after do
+			@sockets.each(&:close)
+		end
+		
+		let(:io) {sockets.first}
+		subject {described_class.new(sockets.last)}
+		
+		it "can read data" do
+			io.write("Hello World")
+			io.close_write
+			
+			expect(subject.read).to be == "Hello World"
+		end
+	end
+	
 	context "socket I/O" do
 		let(:sockets) do
 			@sockets = Async::IO::Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)


### PR DESCRIPTION
In order to help build a bridge between `Async::IO` IO wrappers and native IO, extend `Async::IO::Stream` to support both. In fact, it probably should have been this way from the beginning.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix (ish).
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
